### PR TITLE
RDI-2038 Add OpenGL support

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,7 @@ The [current status](https://github.com/fluendo/gstreamer/compare/main...fluendo
 * ⏳ `wasm-main-enable`: Enable support for wasm [(Branch link)](https://github.com/fluendo/gstreamer/tree/wasm-main-enable)
 * ⏳ `wasm-main-test`: Enable unit tests for wasm [(Branch link)](https://github.com/fluendo/gstreamer/tree/wasm-main-test)
 * ⏳ `wasm-main-openal`: Add emscripten support OpenAL to play audio [(Branch link)](https://github.com/fluendo/gstreamer/tree/wasm-main-openal)
+* ⏳ `wasm-main-gl-support`: Add emscripten OpenGL backend [(Branch link)](https://github.com/fluendo/gstreamer/tree/wasm-main-gl-support)
 * ⏳ `wasm-main-wip`: Commits in progress [(Branch link)](https://github.com/fluendo/gstreamer/tree/wasm-main-wip)
 <!-- END guw gstreamer.toml markdown -->
 
@@ -81,6 +82,7 @@ The [current status](https://github.com/fluendo/cerbero/compare/main...fluendo:c
 * ⏳ `local_source`: New type of source that allows you to build a recipe without fetching or copying sources [(PR link)](https://gitlab.freedesktop.org/gstreamer/cerbero/-/merge_requests/1483)
 * ⏳ `packaging`: Enable installation using pip with a git-https repository [(PR link)](https://gitlab.freedesktop.org/gstreamer/cerbero/-/merge_requests/1484)
 * ⏳ `emscripten`: Add support for building for wasm target with emscripten toolchain [(Branch link)](https://github.com/fluendo/cerbero/tree/emscripten)
+* ⏳ `emscripten-gl`: Add support for building with Emscripten GL backend [(Branch link)](https://github.com/fluendo/cerbero/tree/emscripten-gl)
 <!-- END guw cerbero.toml markdown -->
 
 

--- a/gst.wasm/subprojects/samples/gl/gl-example.c
+++ b/gst.wasm/subprojects/samples/gl/gl-example.c
@@ -1,0 +1,41 @@
+/* Copyright (C) Fluendo S.A. <support@fluendo.com> */
+
+#include <gst/gst.h>
+
+GST_DEBUG_CATEGORY_STATIC (example_dbg);
+#define GST_CAT_DEFAULT example_dbg
+
+static GstElement *pipeline;
+
+static void
+register_elements ()
+{
+  GST_PLUGIN_STATIC_DECLARE (opengl);
+
+  GST_PLUGIN_STATIC_REGISTER (opengl);
+}
+
+static void
+init_pipeline ()
+{
+  pipeline = gst_parse_launch ("gltestsrc ! glimagesink sync=false", NULL);
+  gst_element_set_state (pipeline, GST_STATE_PLAYING);
+}
+
+int
+main (int argc, char **argv)
+{
+  gst_debug_set_default_threshold (2);
+  gst_init (NULL, NULL);
+  GST_DEBUG_CATEGORY_INIT (
+      example_dbg, "example", 0, "videotestsrc wasm example");
+  gst_debug_set_threshold_from_string ("example:5, glwindow*:5", FALSE);
+
+  GST_INFO ("Registering elements");
+  register_elements ();
+
+  GST_INFO ("Initializing pipeline");
+  init_pipeline ();
+
+  return 0;
+}

--- a/gst.wasm/subprojects/samples/gl/meson.build
+++ b/gst.wasm/subprojects/samples/gl/meson.build
@@ -1,0 +1,20 @@
+executable(executable_name,
+    'gl-example.c',
+    dependencies: [common_deps,
+                   dependency('gstopengl')],
+    link_args: common_link_args + [
+      '-lhtml5',
+      '-lGL',
+      '-sOFFSCREENCANVAS_SUPPORT', # To manipulate the gl context from a thread
+      '-sPROXY_TO_PTHREAD', # To avoid deadlock between main thread access like stdout from a thread while main thread is blocked
+    ],
+    name_suffix: 'html',
+    install: true,
+    install_dir: install_dir,
+)
+
+custom_target('js',
+  output: 'gl-example.js',
+  command: ['echo', 'installing js file'],
+  install: true,
+  install_dir: install_dir)

--- a/gst.wasm/subprojects/samples/meson.build
+++ b/gst.wasm/subprojects/samples/meson.build
@@ -20,6 +20,7 @@ common_deps = [gst_dep, gstapp_dep, gstcoreelements_dep, gstaudio_dep, gstvideo_
 examples = [
   'audiotestsrc',
   'emhttpsrc',
+  'gl',
   'gstlaunch',
   'openal',
   'videotestsrc',


### PR DESCRIPTION
This requires several branches to be merged first:

- [x] [GStreamer-OpenGL](https://github.com/fluendo/gstreamer/pull/29) to add OpenGL support in GStreamer
- [x] [Cerbero](https://github.com/fluendo/cerbero/pull/392) to update the list of features in GUW
- [x] [Cerbero](https://github.com/fluendo/cerbero/pull/393) New feature branch
- [x] [GStreamer-GUW](https://github.com/fluendo/gstreamer/pull/25) to update the list of features in GUW

There are still missing processes in order to automate and proceed accordingly when a new branch has to land in the middle of our non-upstreamable commits. In the meantime I've created this to discuss how to proceed.