### PR TITLE
RDI-2126 Fix codecs sample playback until the end

### DIFF
--- a/gst.wasm/subprojects/gst-plugins-web/gst-libs/gst/web/gstwebvideoframe.cpp
+++ b/gst.wasm/subprojects/gst-plugins-web/gst-libs/gst/web/gstwebvideoframe.cpp
@@ -179,6 +179,10 @@ gst_web_video_frame_allocator_free (GstAllocator *allocator, GstMemory *memory)
   /* FIXME can be async */
   gst_web_runner_send_message (
       self->priv->runner, gst_web_video_frame_close, &close_data);
+
+  gst_object_unref (self->priv->runner);
+  self->priv->video_frame = val::undefined ();
+  g_free (self->priv);
 }
 
 static void

--- a/gst.wasm/subprojects/gst-plugins-web/gst/web/codecs/gstwebcodecsvideodecoder.h
+++ b/gst.wasm/subprojects/gst-plugins-web/gst/web/codecs/gstwebcodecsvideodecoder.h
@@ -71,11 +71,8 @@ struct _GstWebCodecsVideoDecoder
   gboolean need_negotiation;
 
   emscripten::val decoder;
-  /* The size of the output frames pending to be dequeued */
+  /* Amount of the output frames pending to be dequeued */
   gint dequeue_size;
-  /* In case we receive a VideoFrame, in order to allow the
-   * blocked stream lock to continue despite the dequeue size */
-  gboolean has_video_frame;
   GMutex dequeue_lock;
   GCond dequeue_cond;
 };

--- a/gst.wasm/subprojects/gst-plugins-web/gst/web/gstwebcanvassink.cpp
+++ b/gst.wasm/subprojects/gst-plugins-web/gst/web/gstwebcanvassink.cpp
@@ -132,6 +132,7 @@ gst_web_canvas_sink_draw_video_frame (gpointer data)
   self->val_context.call<void> ("drawImage", video_frame, 0, 0,
       video_frame["displayWidth"], video_frame["displayHeight"], 0, 0,
       self->val_canvas["width"], self->val_canvas["height"]);
+  gst_memory_unref (GST_MEMORY_CAST (vf));
 }
 
 static void


### PR DESCRIPTION
Decoder was throwing an error after 5:30 minutes of playback because of a VideoFrame leak. Apart from this few more leaks have been fixed too.