### PR TITLE
build: upstream libjpeg-turbo does not build

### DIFF
--- a/build/recipes/libjpeg-turbo.recipe
+++ b/build/recipes/libjpeg-turbo.recipe
@@ -1,0 +1,19 @@
+# -*- Mode: Python -*- vi:si:et:sw=4:sts=4:ts=4:syntax=python
+
+
+class Recipe(recipe.Recipe):
+    name = 'libjpeg-turbo'
+    version = '1.5.3'
+    licenses = [{License.BSD_like: ['LICENSE.md']}]
+    stype = SourceType.TARBALL
+    url = 'sf://.tar.gz'
+    tarball_checksum = 'b24890e2bb46e12e72a79f7e965f409f4e16466d00e1dd15d93d73ee6b592523'
+
+    configure_tpl = "%(config-sh)s --prefix=%(prefix)s "\
+                    "--libdir=%(libdir)s"
+    configure_options = " --with-jpeg8"
+    patches = []
+
+    files_libs = ['libjpeg','libturbojpeg']
+    files_devel = ['include/jpeglib.h', 'include/jerror.h', 'include/jconfig.h',
+                   'include/jmorecfg.h','include/turbojpeg.h', '%(libdir)s/pkgconfig/libjpeg.pc']


### PR DESCRIPTION
CMake is not setting the size of a pointer correctly, go back to previous version.