### PR TITLE
Sync cerbero after tests3 was integrated

### DIFF
--- a/guw/cerbero.gst.wasm.toml
+++ b/guw/cerbero.gst.wasm.toml
@@ -37,7 +37,7 @@ remote = "fluendo"
 name = "tests3"
 summary = "Tests update final round"
 pr = "https://gitlab.freedesktop.org/gstreamer/cerbero/-/merge_requests/1482"
-status = "merging"
+status = "integrated"
 
 [[features]]
 remote = "fluendo"


### PR DESCRIPTION
See
* https://gitlab.freedesktop.org/gstreamer/cerbero/-/merge_requests/1482
* https://github.com/fluendo/spirit-stream/actions/runs/12656399435