### PR TITLE
build: upstream libpng does not build

### DIFF
--- a/build/recipes/libpng.recipe
+++ b/build/recipes/libpng.recipe
@@ -1,0 +1,29 @@
+# -*- Mode: Python -*- vi:si:et:sw=4:sts=4:ts=4:syntax=python
+
+
+class Recipe(recipe.Recipe):
+    name = 'libpng'
+    version = '1.6.37'
+    stype = SourceType.TARBALL
+    url = 'sf://'
+    tarball_checksum = '505e70834d35383537b6491e7ae8641f1a4bed1876dbfe361201fc80868d88ca'
+    licenses = [{License.LibPNG: ['LICENSE']}]
+    deps = ['zlib']
+    patches = [name + '/0001-neon-fix-function-export-names-for-iOS-armv7.patch',
+               name + '/0002-Fix-build-in-native-Windows-do-to-incorrect-r-insert.patch',
+              ]
+
+    files_libs = ['libpng16']
+    files_devel = ['include/libpng16', 'bin/libpng16-config',
+                   '%(libdir)s/pkgconfig/libpng16.pc', '%(libdir)s/pkgconfig/libpng.pc']
+
+    def prepare(self):
+        if self.config.target_platform == Platform.IOS:
+            gas = self.get_env('GAS')
+            if gas:
+                self.set_env('CCAS', gas, '-no-integrated-as')
+        if self.config.target_arch == Architecture.ARM64:
+            self.configure_options += ' --disable-arm-neon '
+        # Needs zlib include flags in CPPFLAGS to generate pnglibconf.h with
+        # the right PNG_ZLIB_VERNUM
+        self.append_env('CPPFLAGS', self.get_env('CFLAGS'))

--- a/build/recipes/libpng/0001-neon-fix-function-export-names-for-iOS-armv7.patch
+++ b/build/recipes/libpng/0001-neon-fix-function-export-names-for-iOS-armv7.patch
@@ -1,0 +1,54 @@
+From 18f113d934c736953f915d6accddc90cb91db6d1 Mon Sep 17 00:00:00 2001
+From: Andoni Morales Alastruey <ylatuya@gmail.com>
+Date: Mon, 28 Oct 2013 13:26:35 +0100
+Subject: [PATCH] neon: fix function export names for iOS armv7
+
+---
+ arm/filter_neon.S | 16 +++++++++++-----
+ 1 file changed, 11 insertions(+), 5 deletions(-)
+
+diff --git a/arm/filter_neon.S b/arm/filter_neon.S
+index 3b061d6..ac08afa 100644
+--- a/arm/filter_neon.S
++++ b/arm/filter_neon.S
+@@ -22,6 +22,12 @@
+ 
+ #ifdef PNG_READ_SUPPORTED
+ 
++#if defined(__APPLE__)
++#define FUNC_PREFIX _
++#else
++#define FUNC_PREFIX
++#endif
++
+ /* Assembler NEON support - only works for 32-bit ARM (i.e. it does not work for
+  * ARM64).  The code in arm/filter_neon_intrinsics.c supports ARM64, however it
+  * only works if -mfpu=neon is specified on the GCC command line.  See pngpriv.h
+@@ -42,7 +48,7 @@
+ 
+ .macro  func    name, export=0
+     .macro endfunc
+-ELF     .size   \name, . - \name
++ELF     .size   FUNC_PREFIX\name, . - FUNC_PREFIX\name
+         .endfunc
+         .purgem endfunc
+     .endm
+@@ -55,11 +61,11 @@ ELF     .size   \name, . - \name
+         .align 2
+ 
+     .if \export
+-        .global \name
++        .global FUNC_PREFIX\name
+     .endif
+-ELF     .type   \name, STT_FUNC
+-        .func   \name
+-\name:
++ELF     .type   FUNC_PREFIX\name, STT_FUNC
++        .func   FUNC_PREFIX\name
++FUNC_PREFIX\name:
+ .endm
+ 
+ func    png_read_filter_row_sub4_neon, export=1
+-- 
+2.1.0
+

--- a/build/recipes/libpng/0002-Fix-build-in-native-Windows-do-to-incorrect-r-insert.patch
+++ b/build/recipes/libpng/0002-Fix-build-in-native-Windows-do-to-incorrect-r-insert.patch
@@ -1,0 +1,40 @@
+From 1ef89bfa98a50ce097fc12329921afd5f86ab1c9 Mon Sep 17 00:00:00 2001
+From: Nacho Garcia <nacho.garglez@gmail.com>
+Date: Wed, 13 Feb 2019 11:32:39 +0100
+Subject: [PATCH 2/2] Fix build in native Windows do to incorrect \r inserted
+
+Somewhere in the pnglibconf.h generation \r characters
+are being added. This happens with the new toolchain
+in native Windows build.
+---
+ Makefile.am | 1 +
+ Makefile.in | 1 +
+ 2 files changed, 2 insertions(+)
+
+diff --git a/Makefile.am b/Makefile.am
+index 08db3e5..ce12b02 100644
+--- a/Makefile.am
++++ b/Makefile.am
+@@ -210,6 +210,7 @@ pnglibconf.h: pnglibconf.out scripts/prefix.out scripts/macro.lst
+ 	   END{print prev}' s=0 pnglibconf.out s=1 scripts/prefix.out\
+ 	   s=2 ${srcdir}/scripts/macro.lst >pnglibconf.tf8
+ 	mv pnglibconf.tf8 $@
++	sed -i -e "s/\r//g" $@
+ 
+ pngprefix.h: scripts/intprefix.out
+ 	rm -f pngprefix.tf1
+diff --git a/Makefile.in b/Makefile.in
+index 79d2b88..e304b2a 100644
+--- a/Makefile.in
++++ b/Makefile.in
+@@ -2268,6 +2268,7 @@ libpng.vers: scripts/vers.out
+ @DO_PNG_PREFIX_FALSE@pnglibconf.h: pnglibconf.out
+ @DO_PNG_PREFIX_FALSE@	rm -f $@
+ @DO_PNG_PREFIX_FALSE@	cp $? $@
++@DO_PNG_PREFIX_FALSE@	sed -i -e "s/\r//g" $@
+ 
+ @DO_PNG_PREFIX_FALSE@pngprefix.h: # is empty
+ @DO_PNG_PREFIX_FALSE@	:>$@
+-- 
+2.18.0.windows.1
+


### PR DESCRIPTION
libpng was updated to 1.6.43 and port to CMake.
As for jpeg-turbo CMake is not setting the size of a pointer correctly, go back to previous version.

[1] https://gitlab.freedesktop.org/gstreamer/cerbero/-/merge_requests/1548