### PR TITLE
Skip issue with llvm.clear_cache and wasm inside orc 0.4.1

### DIFF
--- a/build/recipes/orc.recipe
+++ b/build/recipes/orc.recipe
@@ -1,0 +1,48 @@
+# -*- Mode: Python -*- vi:si:et:sw=4:sts=4:ts=4:syntax=python
+from cerbero.tools.libtool import LibtoolLibrary
+
+class Recipe(recipe.Recipe):
+    name = 'orc'
+    version = '0.4.40'
+
+    stype = SourceType.TARBALL
+    # These properties are only used when stype is TARBALL
+    url = 'https://gstreamer.freedesktop.org/src/orc/orc-%(version)s.tar.xz'
+    tarball_checksum = '3fc2bee78dfb7c41fd9605061fc69138db7df007eae2f669a1f56e8bacef74ab'
+    # These properties are only used when stype is GIT
+    remotes = {'origin': 'https://gitlab.freedesktop.org/gstreamer/orc.git'}
+    commit = 'origin/main'
+
+    patches = [
+        'orc//0001-opcodes-Use-MIN-instead-of-CLAMP-for-known-unsigned-.patch',
+    ]
+
+    btype = BuildType.MESON
+    licenses = [{License.BSD_like: ['COPYING']}]
+    meson_options = {'benchmarks': 'disabled', 'tests': 'disabled',
+                     'tools': 'enabled', 'orc-test': 'enabled'}
+
+    files_libs = ['liborc-0.4']
+    files_devel = ['include/orc-0.4', '%(libdir)s/pkgconfig/orc-0.4.pc',
+        'bin/orcc%(bext)s']
+
+    def prepare(self):
+        # Don't build testing helper library on ios
+        if self.config.target_platform != Platform.IOS:
+            self.files_libs.append('liborc-test-0.4')
+            self.files_devel.append('bin/orc-bugreport%(bext)s')
+        else:
+            self.meson_options['orc-test'] = 'disabled'
+
+    def post_install(self):
+        dependency_libs = []
+        if self.config.target_platform == Platform.ANDROID:
+            dependency_libs += ['-lm', '-llog']
+
+        lib = LibtoolLibrary('orc-0.4', None, None, None, self.config.libdir,
+                self.config.target_platform, deps=dependency_libs)
+        lib.save()
+        if self.config.target_platform != Platform.IOS:
+            lib = LibtoolLibrary('orc-test-0.4', None, None, None, self.config.libdir,
+                    self.config.target_platform, deps=dependency_libs + ['orc-0.4']).save()
+        super().post_install()

--- a/build/recipes/orc/0001-opcodes-Use-MIN-instead-of-CLAMP-for-known-unsigned-.patch
+++ b/build/recipes/orc/0001-opcodes-Use-MIN-instead-of-CLAMP-for-known-unsigned-.patch
@@ -1,0 +1,40 @@
+From f26d40a3fedca74d4a7a34042b09d62ca8ed68e8 Mon Sep 17 00:00:00 2001
+From: Edward Hervey <bilboed@bilboed.com>
+Date: Sun, 5 Jan 2025 12:05:05 +0100
+Subject: [PATCH] opcodes: Use MIN instead of CLAMP for known unsigned values
+
+The same fix was already done for other times ages ago. These two were missing
+
+Part-of: <https://gitlab.freedesktop.org/gstreamer/orc/-/merge_requests/212>
+---
+ orc/opcodes.h | 8 ++++----
+ 1 file changed, 4 insertions(+), 4 deletions(-)
+
+diff --git a/orc/opcodes.h b/orc/opcodes.h
+index b3c5a09..5b979a9 100644
+--- a/orc/opcodes.h
++++ b/orc/opcodes.h
+@@ -110,16 +110,16 @@ UNARY_LW(convlw, "%s")
+ UNARY_WB(convhlw, "((orc_uint32)%s)>>16")
+ UNARY_LW(convssslw, "ORC_CLAMP_SW(%s)")
+ UNARY_LW(convsuslw, "ORC_CLAMP_UW(%s)")
+-UNARY_LW(convusslw, "ORC_CLAMP((orc_uint32)%s,0,ORC_SW_MAX)")
+-UNARY_LW(convuuslw, "ORC_CLAMP_UW((orc_uint32)%s)")
++UNARY_LW(convusslw, "ORC_MIN((orc_uint32)%s, ORC_SW_MAX)")
++UNARY_LW(convuuslw, "ORC_MIN((orc_uint32)%s, ORC_UW_MAX)")
+ 
+ UNARY_LQ(convslq, "%s")
+ UNARY_LQ(convulq, "(orc_uint32)%s")
+ UNARY_LW(convql, "%s")
+ UNARY_LW(convsssql, "ORC_CLAMP_SL(%s)")
+ UNARY_LW(convsusql, "ORC_CLAMP_UL(%s)")
+-UNARY_LW(convussql, "ORC_CLAMP_SL((orc_uint64)%s)")
+-UNARY_LW(convuusql, "ORC_CLAMP_UL((orc_uint64)%s)")
++UNARY_LW(convussql, "ORC_MIN((orc_uint64)%s, ORC_SL_MAX)")
++UNARY_LW(convuusql, "ORC_MIN((orc_uint64)%s, ORC_UL_MAX)")
+ 
+ BINARY_BW(mulsbw, "%s * %s")
+ BINARY_BW(mulubw, "((orc_uint16)((orc_uint8)%s)) * ((orc_uint16)((orc_uint8)%s))")
+-- 
+2.45.2
+


### PR DESCRIPTION
Using orc version 0.4.0 until fixing the issue related to llvm.clear_cache is not supported on wasm added in commit [1]

[1] https://gitlab.freedesktop.org/gstreamer/orc/-/commit/693132057fd005a07437d79cc7f7951562c0f41e

<details>
 <summary>Full error</summary>

```
[cerbero-web-] [rgonzalez@rgonzalez-ThinkPad-T14 b]$ /home/rgonzalez/src/github.com/fluendo/gst.wasm/build/gst.wasm_web_wasm32/emsdk/upstream/emscripten/emcc -Iorc/liborc-0.4.a.p -Iorc -I../orc -I. -I.. -I/home/rgonzalez/src/github.com/fluendo/gst.wasm/build/gst.wasm_web_wasm32/dist/web_wasm32/include -fdiagnostics-color=always -D_FILE_OFFSET_BITS=64 -Wall -Winvalid-pch -O2 -g -DHAVE_CONFIG_H -Werror=implicit-int -Werror=implicit-function-declaration -fvisibility=hidden -O3 -pthread -fexceptions -mnontrapping-fptoint -msimd128 -DWASM_SIMD_COMPAT_SLOW -DWASM_BIGINT -fPIC -fPIC -DORC_ENABLE_UNSTABLE_API -D_GNU_SOURCE -DBUILDING_ORC -MD -MQ orc/liborc-0.4.a.p/orcprogram-x86.c.o -MF orc/liborc-0.4.a.p/orcprogram-x86.c.o.d -o orc/liborc-0.4.a.p/orcprogram-x86.c.o -c ../orc/orcprogram-x86.c
fatal error: error in backend: llvm.clear_cache is not supported on wasm
PLEASE submit a bug report to https://github.com/llvm/llvm-project/issues/ and include the crash backtrace, preprocessed source, and associated run script.
Stack dump:
0.      Program arguments: /home/rgonzalez/src/github.com/fluendo/gst.wasm/build/gst.wasm_web_wasm32/emsdk/upstream/bin/clang -target wasm32-unknown-emscripten -mllvm -combiner-global-alias-analysis=false -mllvm -enable-emscripten-cxx-exceptions -mllvm -enable-emscripten-sjlj -mllvm -disable-lsr --sysroot=/home/rgonzalez/src/github.com/fluendo/gst.wasm/build/gst.wasm_web_wasm32/emsdk/upstream/emscripten/cache/sysroot -D__EMSCRIPTEN_SHARED_MEMORY__=1 -DEMSCRIPTEN -Werror=implicit-function-declaration -Xclang -iwithsysroot/include/fakesdl -Xclang -iwithsysroot/include/compat -Iorc/liborc-0.4.a.p -Iorc -I../orc -I. -I.. -I/home/rgonzalez/src/github.com/fluendo/gst.wasm/build/gst.wasm_web_wasm32/dist/web_wasm32/include -fdiagnostics-color=always -D_FILE_OFFSET_BITS=64 -Wall -Winvalid-pch -O2 -g3 -DHAVE_CONFIG_H -Werror=implicit-int -Werror=implicit-function-declaration -fvisibility=hidden -O3 -pthread -fexceptions -mnontrapping-fptoint -msimd128 -DWASM_SIMD_COMPAT_SLOW -DWASM_BIGINT -fPIC -fPIC -DORC_ENABLE_UNSTABLE_API -D_GNU_SOURCE -DBUILDING_ORC -MD -MQ orc/liborc-0.4.a.p/orcprogram-x86.c.o -MF orc/liborc-0.4.a.p/orcprogram-x86.c.o.d -c -matomics -mbulk-memory ../orc/orcprogram-x86.c -o orc/liborc-0.4.a.p/orcprogram-x86.c.o
1.      <eof> parser at end of file
2.      Code generation
3.      Running pass 'Function Pass Manager' on module '../orc/orcprogram-x86.c'.
4.      Running pass 'WebAssembly Instruction Selection' on function '@orc_x86_flush_cache'
 #0 0x00005cbedfe9aa58 llvm::sys::PrintStackTrace(llvm::raw_ostream&, int) (/home/rgonzalez/src/github.com/fluendo/gst.wasm/build/gst.wasm_web_wasm32/emsdk/upstream/bin/clang+0x307fa58)
 #1 0x00005cbedfe97dae llvm::sys::RunSignalHandlers() (/home/rgonzalez/src/github.com/fluendo/gst.wasm/build/gst.wasm_web_wasm32/emsdk/upstream/bin/clang+0x307cdae)
 #2 0x00005cbedfe99c9f llvm::sys::CleanupOnSignal(unsigned long) (/home/rgonzalez/src/github.com/fluendo/gst.wasm/build/gst.wasm_web_wasm32/emsdk/upstream/bin/clang+0x307ec9f)
 #3 0x00005cbedfdfa02e (anonymous namespace)::CrashRecoveryContextImpl::HandleCrash(int, unsigned long) (.llvm.12059184700174258416) CrashRecoveryContext.cpp:0:0
 #4 0x00005cbedfdf9feb (/home/rgonzalez/src/github.com/fluendo/gst.wasm/build/gst.wasm_web_wasm32/emsdk/upstream/bin/clang+0x2fdefeb)
 #5 0x00005cbedfe9457b (/home/rgonzalez/src/github.com/fluendo/gst.wasm/build/gst.wasm_web_wasm32/emsdk/upstream/bin/clang+0x307957b)
 #6 0x00005cbedeb53631 (/home/rgonzalez/src/github.com/fluendo/gst.wasm/build/gst.wasm_web_wasm32/emsdk/upstream/bin/clang+0x1d38631)
 #7 0x00005cbedfdff647 llvm::report_fatal_error(llvm::Twine const&, bool) (/home/rgonzalez/src/github.com/fluendo/gst.wasm/build/gst.wasm_web_wasm32/emsdk/upstream/bin/clang+0x2fe4647)
 #8 0x00005cbedfdff516 (/home/rgonzalez/src/github.com/fluendo/gst.wasm/build/gst.wasm_web_wasm32/emsdk/upstream/bin/clang+0x2fe4516)
 #9 0x00005cbedebef5ae llvm::WebAssemblyTargetLowering::LowerOperation(llvm::SDValue, llvm::SelectionDAG&) const WebAssemblyISelLowering.cpp:0:0
#10 0x00005cbee1160b9c (anonymous namespace)::SelectionDAGLegalize::LegalizeOp(llvm::SDNode*) (.llvm.13014211348203958130) LegalizeDAG.cpp:0:0
#11 0x00005cbee1160070 llvm::SelectionDAG::Legalize() (/home/rgonzalez/src/github.com/fluendo/gst.wasm/build/gst.wasm_web_wasm32/emsdk/upstream/bin/clang+0x4345070)
#12 0x00005cbee124c3be llvm::SelectionDAGISel::CodeGenAndEmitDAG() (/home/rgonzalez/src/github.com/fluendo/gst.wasm/build/gst.wasm_web_wasm32/emsdk/upstream/bin/clang+0x44313be)
#13 0x00005cbee124b9bd llvm::SelectionDAGISel::SelectAllBasicBlocks(llvm::Function const&) (/home/rgonzalez/src/github.com/fluendo/gst.wasm/build/gst.wasm_web_wasm32/emsdk/upstream/bin/clang+0x44309bd)
#14 0x00005cbee12484f2 llvm::SelectionDAGISel::runOnMachineFunction(llvm::MachineFunction&) (/home/rgonzalez/src/github.com/fluendo/gst.wasm/build/gst.wasm_web_wasm32/emsdk/upstream/bin/clang+0x442d4f2)
#15 0x00005cbee12463b1 llvm::SelectionDAGISelLegacy::runOnMachineFunction(llvm::MachineFunction&) (/home/rgonzalez/src/github.com/fluendo/gst.wasm/build/gst.wasm_web_wasm32/emsdk/upstream/bin/clang+0x442b3b1)
#16 0x00005cbedf3cc932 llvm::MachineFunctionPass::runOnFunction(llvm::Function&) (/home/rgonzalez/src/github.com/fluendo/gst.wasm/build/gst.wasm_web_wasm32/emsdk/upstream/bin/clang+0x25b1932)
#17 0x00005cbedf92f04d llvm::FPPassManager::runOnFunction(llvm::Function&) (/home/rgonzalez/src/github.com/fluendo/gst.wasm/build/gst.wasm_web_wasm32/emsdk/upstream/bin/clang+0x2b1404d)
#18 0x00005cbedf938883 llvm::FPPassManager::runOnModule(llvm::Module&) (/home/rgonzalez/src/github.com/fluendo/gst.wasm/build/gst.wasm_web_wasm32/emsdk/upstream/bin/clang+0x2b1d883)
#19 0x00005cbedf92ffca llvm::legacy::PassManagerImpl::run(llvm::Module&) (/home/rgonzalez/src/github.com/fluendo/gst.wasm/build/gst.wasm_web_wasm32/emsdk/upstream/bin/clang+0x2b14fca)
#20 0x00005cbee0748e66 clang::EmitBackendOutput(clang::DiagnosticsEngine&, clang::HeaderSearchOptions const&, clang::CodeGenOptions const&, clang::TargetOptions const&, clang::LangOptions const&, llvm::StringRef, llvm::Module*, clang::BackendAction, llvm::IntrusiveRefCntPtr<llvm::vfs::FileSystem>, std::__2::unique_ptr<llvm::raw_pwrite_stream, std::__2::default_delete<llvm::raw_pwrite_stream>>, clang::BackendConsumer*) (/home/rgonzalez/src/github.com/fluendo/gst.wasm/build/gst.wasm_web_wasm32/emsdk/upstream/bin/clang+0x392de66)
#21 0x00005cbee0763289 clang::BackendConsumer::HandleTranslationUnit(clang::ASTContext&) (/home/rgonzalez/src/github.com/fluendo/gst.wasm/build/gst.wasm_web_wasm32/emsdk/upstream/bin/clang+0x3948289)
#22 0x00005cbee1ccdef9 clang::ParseAST(clang::Sema&, bool, bool) (/home/rgonzalez/src/github.com/fluendo/gst.wasm/build/gst.wasm_web_wasm32/emsdk/upstream/bin/clang+0x4eb2ef9)
#23 0x00005cbee0c37a71 clang::FrontendAction::Execute() (/home/rgonzalez/src/github.com/fluendo/gst.wasm/build/gst.wasm_web_wasm32/emsdk/upstream/bin/clang+0x3e1ca71)
#24 0x00005cbee0b87e00 clang::CompilerInstance::ExecuteAction(clang::FrontendAction&) (/home/rgonzalez/src/github.com/fluendo/gst.wasm/build/gst.wasm_web_wasm32/emsdk/upstream/bin/clang+0x3d6ce00)
#25 0x00005cbee0d358d7 clang::ExecuteCompilerInvocation(clang::CompilerInstance*) (/home/rgonzalez/src/github.com/fluendo/gst.wasm/build/gst.wasm_web_wasm32/emsdk/upstream/bin/clang+0x3f1a8d7)
#26 0x00005cbedeb52d4f cc1_main(llvm::ArrayRef<char const*>, char const*, void*) (/home/rgonzalez/src/github.com/fluendo/gst.wasm/build/gst.wasm_web_wasm32/emsdk/upstream/bin/clang+0x1d37d4f)
#27 0x00005cbedeb4f383 ExecuteCC1Tool(llvm::SmallVectorImpl<char const*>&, llvm::ToolContext const&) driver.cpp:0:0
#28 0x00005cbee09da919 void llvm::function_ref<void ()>::callback_fn<clang::driver::CC1Command::Execute(llvm::ArrayRef<std::__2::optional<llvm::StringRef>>, std::__2::basic_string<char, std::__2::char_traits<char>, std::__2::allocator<char>>*, bool*) const::$_0>(long) Job.cpp:0:0
#29 0x00005cbedfdf9fc8 llvm::CrashRecoveryContext::RunSafely(llvm::function_ref<void ()>) (/home/rgonzalez/src/github.com/fluendo/gst.wasm/build/gst.wasm_web_wasm32/emsdk/upstream/bin/clang+0x2fdefc8)
#30 0x00005cbee09da274 clang::driver::CC1Command::Execute(llvm::ArrayRef<std::__2::optional<llvm::StringRef>>, std::__2::basic_string<char, std::__2::char_traits<char>, std::__2::allocator<char>>*, bool*) const (/home/rgonzalez/src/github.com/fluendo/gst.wasm/build/gst.wasm_web_wasm32/emsdk/upstream/bin/clang+0x3bbf274)
#31 0x00005cbee0996d88 clang::driver::Compilation::ExecuteCommand(clang::driver::Command const&, clang::driver::Command const*&, bool) const (/home/rgonzalez/src/github.com/fluendo/gst.wasm/build/gst.wasm_web_wasm32/emsdk/upstream/bin/clang+0x3b7bd88)
#32 0x00005cbee09b66ac clang::driver::Driver::ExecuteCompilation(clang::driver::Compilation&, llvm::SmallVectorImpl<std::__2::pair<int, clang::driver::Command const*>>&) (/home/rgonzalez/src/github.com/fluendo/gst.wasm/build/gst.wasm_web_wasm32/emsdk/upstream/bin/clang+0x3b9b6ac)
#33 0x00005cbedeb4e337 clang_main(int, char**, llvm::ToolContext const&) (/home/rgonzalez/src/github.com/fluendo/gst.wasm/build/gst.wasm_web_wasm32/emsdk/upstream/bin/clang+0x1d33337)
#34 0x00005cbedeb5e49a main (/home/rgonzalez/src/github.com/fluendo/gst.wasm/build/gst.wasm_web_wasm32/emsdk/upstream/bin/clang+0x1d4349a)
#35 0x00007e74381ab488 (/usr/lib/libc.so.6+0x27488)
#36 0x00007e74381ab54c __libc_start_main (/usr/lib/libc.so.6+0x2754c)
#37 0x00005cbedeabebea _start (/home/rgonzalez/src/github.com/fluendo/gst.wasm/build/gst.wasm_web_wasm32/emsdk/upstream/bin/clang+0x1ca3bea)
clang: error: clang frontend command failed with exit code 70 (use -v to see invocation)
clang version 20.0.0git (https:/github.com/llvm/llvm-project 5cc64bf60bc04b9315de3c679eb753de4d554a8a)
Target: wasm32-unknown-emscripten
Thread model: posix
InstalledDir: /home/rgonzalez/src/github.com/fluendo/gst.wasm/build/gst.wasm_web_wasm32/emsdk/upstream/bin
clang: note: diagnostic msg:
********************

PLEASE ATTACH THE FOLLOWING FILES TO THE BUG REPORT:
Preprocessed source(s) and associated run script(s) are located at:
clang: note: diagnostic msg: /tmp/orcprogram-x86-ff5bf7.c
clang: note: diagnostic msg: /tmp/orcprogram-x86-ff5bf7.sh
clang: note: diagnostic msg:

********************
```

</details>
