### PR TITLE
samples/avdec: reduce max-threads to 4

### DIFF
--- a/gst.wasm/subprojects/samples/codecs-avdec-h264/codecs-avdec-h264-example.c
+++ b/gst.wasm/subprojects/samples/codecs-avdec-h264/codecs-avdec-h264-example.c
@@ -63,7 +63,7 @@ init_pipeline ()
       "webstreamsrc "
       "location=\"" GSTWASM_AVDEC_H264_EXAMPLE_SRC "\" ! "
       "qtdemux ! "
-      "avdec_h264 qos=false ! videoconvert ! queue ! webcanvassink",
+      "avdec_h264 qos=false max-threads=4 ! videoconvert ! queue ! webcanvassink",
       NULL);
   gst_element_set_state (pipeline, GST_STATE_PLAYING);
 }

--- a/gst.wasm/subprojects/samples/dash/dash-example.c
+++ b/gst.wasm/subprojects/samples/dash/dash-example.c
@@ -76,7 +76,7 @@ init_pipeline ()
       "dashdemux presentation-delay=2s "
       "max-video-width=" G_STRINGIFY (CANVAS_WIDTH) " max-video-height=" G_STRINGIFY (CANVAS_HEIGHT) " ! "
       "video/quicktime ! qtdemux ! queue ! "
-      "avdec_h264 qos=false ! videoconvert ! webcanvassink",
+      "avdec_h264 qos=false max-threads=4 ! videoconvert ! webcanvassink",
       NULL);
   gst_element_set_state (pipeline, GST_STATE_PLAYING);
 }


### PR DESCRIPTION
It seems that it creates 16 threads by default that affects RAM consumption: each thread takes ~1.5 Mb of RAM. Reducing threads to 4 lowers the RAM consumption from 43 to 30 Mb, at the same time it should positively affect the performance because TVs usually have 4-8 cores, and there're other threads doing things as well.

Issue: CS_3392